### PR TITLE
Bug hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Revision history for hierarchical-env
 
+## 0.2.0.0 -- 2021-04-28
+* Change how to specify the super environment
+  * Before: Specify by adding type instance for `Super env`
+    
+    ```haskell
+    data Env = Env !BaseEnv !Int
+    deriveEnv ''Env
+    type instance Super Env = BaseEnv
+    ```
+  * After: Wrapping the super environment field with `Extends`
+
+    ```haskell
+    data Env = Env !(Extends BaseEnv) !Int
+    deriveEnv ''Env
+    ```
+* Fix the type error bug occurs when hiding dependencies.
+
+
 ## 0.1.0.0 -- 2021-04-22
 
 * First version. Released on an unsuspecting world.

--- a/hierarchical-env.cabal
+++ b/hierarchical-env.cabal
@@ -7,8 +7,9 @@ cabal-version:      2.4
 name:               hierarchical-env
 version:            0.1.0.0
 synopsis:           hierarchical environments for dependency injection
+description:
+  This library provides scalable dependency injection for RIO monad
 
-description:        This library provides scalable dependency injection for RIO monad
 homepage:           https://github.com/autotaker/hierarchical-env
 
 -- bug-reports:
@@ -18,7 +19,7 @@ author:             Taku Terao
 maintainer:         autotaker@gmail.com
 
 -- copyright:
-category: Control
+category:           Control
 extra-source-files:
   CHANGELOG.md
   README.md
@@ -31,7 +32,7 @@ common shared-properties
     , microlens-mtl     ^>=0.2
     , microlens-th      ^>=0.4
     , rio               >=0.1.16.0
-    , template-haskell  >=2.15 && < 2.18
+    , template-haskell  >=2.15     && <2.18
     , th-abstraction    ^>=0.4.2.0
 
   default-language: Haskell2010

--- a/hierarchical-env.cabal
+++ b/hierarchical-env.cabal
@@ -5,7 +5,7 @@ cabal-version:      2.4
 -- http://haskell.org/cabal/users-guide/
 
 name:               hierarchical-env
-version:            0.1.0.0
+version:            0.2.0.0
 synopsis:           hierarchical environments for dependency injection
 description:
   This library provides scalable dependency injection for RIO monad

--- a/src/Control/Env/Hierarchical.hs
+++ b/src/Control/Env/Hierarchical.hs
@@ -24,8 +24,8 @@ module Control.Env.Hierarchical
 
     -- ** With hierarchical environments
     -- $usage:hierarchical
-    Root,
-    Super,
+    Environment (Super, superL),
+    Extends (Extends),
     deriveEnv,
 
     -- * Hiding dependencies
@@ -36,10 +36,11 @@ module Control.Env.Hierarchical
 where
 
 import Control.Env.Hierarchical.Internal
-  ( Has,
+  ( Environment (Super, superL),
+    Extends (Extends),
+    Has,
     Has1,
     Root,
-    Super,
     getL,
     runIF,
   )
@@ -103,7 +104,6 @@ import Control.Method (Interface (IBase, mapBase), mapBaseRIO)
 --
 -- @
 -- 'deriveEnv' ''Env
--- type instance 'Super' Env = 'Root'
 -- @
 --
 -- Now, you can inject dependency by specifying the actual value of @Env@
@@ -125,7 +125,7 @@ import Control.Method (Interface (IBase, mapBase), mapBaseRIO)
 
 -- $usage:hierarchical
 -- Instead of resolving the dependency universally,
--- you can extend environments by specifying the super environment.
+-- you can extend environments by adding @Extend T@ as a field.
 --
 -- In the following example @ExtEnv@ inherits @BaseEnv@.
 -- The extended environment is a nominal sub-type of its super environment,
@@ -138,12 +138,10 @@ import Control.Method (Interface (IBase, mapBase), mapBaseRIO)
 -- data BaseEnv = BaseEnv !ServerName !ConnectionPool
 --
 -- 'deriveEnv' ''BaseEnv
--- type instance 'Super' BaseEnv = 'Root'
 --
--- data ExtEnv = ExtEnv !BaseEnv !(UserRepo ExtEnv)
+-- data ExtEnv = ExtEnv !(Extends BaseEnv) !(UserRepo ExtEnv)
 --
 -- 'deriveEnv' ''ExtEnv
--- type instance 'Super' ExtEnv = BaseEnv
 -- @
 --
 -- Then, @ExtEnv@ resolves the dependencies.
@@ -158,7 +156,7 @@ import Control.Method (Interface (IBase, mapBase), mapBaseRIO)
 -- runApp :: ServerName -> ConnectionPool -> [UserName] -> IO ()
 -- runApp serverName pool users = do
 --   let baseEnv = BaseEnv serverName pool
---       extEnv = ExtEnv baseEnv userRepoImpl
+--       extEnv = ExtEnv (Extends baseEnv) userRepoImpl
 --   runRIO extEnv $ do
 --     printServerName
 --     forM_ users $ \usernm -> do
@@ -214,12 +212,11 @@ import Control.Method (Interface (IBase, mapBase), mapBaseRIO)
 -- instance 'Interface' AuthHandler where
 --   type 'IBase' AuthHandler = RIO
 --
--- data AuthEnv env = AuthEnv !(UserRepo (AutheEnv env)) !env
+-- data AuthEnv env = AuthEnv !(UserRepo (AutheEnv env)) !(Extends env)
 -- 'deriveEnv' ''AuthEnv
--- type instance 'Super' (AuthEnv env) = env
 --
 -- authHandlerImpl :: ('Has' ConnectionPool env) => AuthHandler env
--- authHandlerImpl = 'mapBaseRIO' (AuthEnv userRepoImpl) handler
+-- authHandlerImpl = 'mapBaseRIO' (AuthEnv userRepoImpl . Extends) handler
 --   where
 --     handler = AuthHandler signinImpl signupImpl
 -- @

--- a/src/Control/Env/Hierarchical.hs
+++ b/src/Control/Env/Hierarchical.hs
@@ -40,7 +40,6 @@ import Control.Env.Hierarchical.Internal
     Extends (Extends),
     Has,
     Has1,
-    Root,
     getL,
     runIF,
   )

--- a/src/Control/Env/Hierarchical/Internal.hs
+++ b/src/Control/Env/Hierarchical/Internal.hs
@@ -50,8 +50,8 @@ import RIO (RIO, runRIO)
 class Environment env where
   -- | @Super env@ represents the inheritance relation between environments.
   --
-  -- * If @env@ owns a field of the form @Extends T@, then @T@ is the super environment.
-  -- * If @env@ owns no field of the form @Extends T@, then 'Root' is the super environment.
+  -- * If @env@ owns a field of the form @'Extends' T@, then @T@ is the super environment.
+  -- * If @env@ owns no field of the form @'Extends' T@, then 'Root' is the super environment.
   -- * Every @env@ must have at most one field of the form @Extends T@ because multiple inheritance is not supported.
   type Super env
 

--- a/src/Control/Env/Hierarchical/Internal.hs
+++ b/src/Control/Env/Hierarchical/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -21,17 +22,18 @@
 -- Stability: experimental
 module Control.Env.Hierarchical.Internal
   ( Environment (..),
-    Super,
+    Extends (..),
     Root (..),
     Field (..),
     Trans (..),
-    --    type (<:),
     SomeInterface (SomeInterface),
     Has,
     Has1,
     getL,
     ifaceL,
     runIF,
+    rootL,
+    extendsL,
   )
 where
 
@@ -45,25 +47,44 @@ import Lens.Micro (Lens')
 import Lens.Micro.Mtl (view)
 import RIO (RIO, runRIO)
 
--- | @Super env@ represents the inheritance relation between environments.
--- Every environment must be a descendant of 'Root'.
-type family Super env
-
 class Environment env where
+  -- | @Super env@ represents the inheritance relation between environments.
+  --
+  -- * If @env@ owns a field of the form @Extends T@, then @T@ is the super environment.
+  -- * If @env@ owns no field of the form @Extends T@, then 'Root' is the super environment.
+  -- * Every @env@ must have at most one field of the form @Extends T@ because multiple inheritance is not supported.
+  type Super env
+
   -- | interfaces that are fields of the environment
   type Fields1 env :: [Type -> Type]
 
   -- | fields of the environment
   type Fields env :: [Type]
 
+  -- | Lens to super environment
+  superL :: Lens' env (Super env)
+  {-# INLINE superL #-}
+  default superL :: Field (Extends (Super env)) env => Lens' env (Super env)
+  superL = fieldL . extendsL
+
 -- | Root environment that does not have any fields.
 data Root = Root
 
-type instance Super Root = TypeError ('Text "No super environment for Root")
+-- | Wrapper that represents the super environment.
+newtype Extends env = Extends env
+
+{-# INLINE extendsL #-}
+extendsL :: Lens' (Extends x) x
+extendsL f (Extends x) = fmap Extends (f x)
+
+rootL :: Lens' x Root
+rootL f x = x <$ f Root
 
 instance Environment Root where
+  type Super Root = TypeError ('Text "No super environment for Root")
   type Fields1 Root = '[]
   type Fields Root = '[]
+  superL = undefined
 
 -- | direct field of @env@
 class Field a env where
@@ -86,9 +107,9 @@ instance Trans s '[] where
   type Target s '[] = s
   transL = id
 
-instance (Field t s, Trans t l) => Trans s (t : l) where
+instance (Environment s, Super s ~ t, Trans t l) => Trans s (t : l) where
   type Target s (t : l) = Target t l
-  transL = fieldL . transL @t @l
+  transL = superL . transL @t @l
 
 -- env1 <: env2 <: env3
 -- Addr env1 env3 = [env2, env3]
@@ -98,26 +119,20 @@ type family Addr a :: [Type] where
   Addr Root = '[]
   Addr a = Super a ': Addr (Super a)
 
-type family Ancestors env :: [Type] where
-  Ancestors env = env ': Addr env
-
 type family Member (f :: k) (l :: [k]) :: Bool where
   Member f '[] = 'False
   Member f (f : l) = 'True
   Member f (g : l) = Member f l
 
-type family FindEnv (f :: Type) (envs :: [Type]) :: [Type] where
-  FindEnv f (env ': envs) = env ': If (Member f (Fields env)) '[] (FindEnv f envs)
-  FindEnv f '[] = TypeError ('Text "No environment has " ':<>: 'ShowType f)
+-- X <- Env1, FindEnv X Env1 [Env2,Root] => []
+-- X <- Env2, FindEnv X Env1 [Env2,Root] => [Env2]
+type family FindEnv (f :: Type) env (envs :: [Type]) :: [Type] where
+  FindEnv f env (env' ': envs) = If (Member f (Fields env)) '[] (env' : FindEnv f env' envs)
+  FindEnv f env '[] = TypeError ('Text "No environment has " ':<>: 'ShowType f)
 
-type family FindEnv1 (f :: Type -> Type) (envs :: [Type]) :: [Type] where
-  FindEnv1 f (env ': envs) = env ': If (Member f (Fields1 env)) '[] (FindEnv1 f envs)
-  FindEnv1 f '[] = TypeError ('Text "No environment has " ':<>: 'ShowType f)
-
--- type (<:) env env' = (Trans env (Tail (Addr env env')), Target env (Tail (Addr env env')) ~ env')
-
-type family Tail (l :: [Type]) where
-  Tail (x : xs) = xs
+type family FindEnv1 (f :: Type -> Type) env (envs :: [Type]) :: [Type] where
+  FindEnv1 f env (env' ': envs) = If (Member f (Fields1 env)) '[] (env' : FindEnv1 f env' envs)
+  FindEnv1 f env '[] = TypeError ('Text "No environment has " ':<>: 'ShowType f)
 
 data SomeInterface f env where
   SomeInterface :: Lens' env' (f env') -> Lens' env env' -> SomeInterface f env
@@ -132,21 +147,21 @@ type Has1Aux f env route = (Trans env route, Field (f (Target env route)) (Targe
 -- @Has T env@. If you want to depends on multiple values of the same type,
 -- please distinguish them by using newtype.
 type family Has a env where
-  Has a env = HasAux a env (Tail (FindEnv a (Ancestors env)))
+  Has a env = HasAux a env (FindEnv a env (Addr env))
 
 -- | Type constraint meaning @env@ contains @f env'@ for some ancestor @env'@
 type family Has1 f env where
-  Has1 f env = Has1Aux f env (Tail (FindEnv1 f (Ancestors env)))
+  Has1 f env = Has1Aux f env (FindEnv1 f env (Addr env))
 
 -- | Lens to extract @a@ from @env@
 getL :: forall a env. Has a env => Lens' env a
-getL = transL @env @(Tail (FindEnv a (Ancestors env))) . fieldL
+getL = transL @env @(FindEnv a env (Addr env)) . fieldL
 
 ifaceL :: forall f env. Has1 f env => SomeInterface f env
 ifaceL =
   SomeInterface
-    (fieldL @(f (Target env (Tail (FindEnv1 f (Ancestors env))))))
-    (transL @env @(Tail (FindEnv1 f (Ancestors env))))
+    (fieldL @(f (Target env (FindEnv1 f env (Addr env)))))
+    (transL @env @(FindEnv1 f env (Addr env)))
 
 -- | Run action that depends on an interface @f@.
 -- The action must be polymorphic to @env'@,
@@ -154,36 +169,7 @@ ifaceL =
 runIF :: forall f env a. Has1 f env => (forall env'. f env' -> RIO env' a) -> RIO env a
 runIF body =
   case ifaceL @f of
-    SomeInterface _ifaceL superL -> do
-      iface <- view $ superL . _ifaceL
-      env <- view superL
+    SomeInterface _ifaceL _superL -> do
+      iface <- view $ _superL . _ifaceL
+      env <- view _superL
       runRIO env (body iface)
-
-{-
-data Env1 = Env1 Int Char
-
-type instance Super Env1 = Root
-
-instance Environment Env1 where
-  type Fields Env1 = '[Int, Char]
-  type Fields1 Env1 = '[]
-
-instance Field Int Env1 where
-  fieldL f (Env1 x1 x2) = fmap (\y1 -> Env1 y1 x2) (f x1)
-
-ex :: Lens' Env1 Int
-ex = getL
-
-ex2 :: Int
-ex2 = t1 + t2
-  where
-    t1 :: (Ancestors Env1 ~ '[Env1, Root]) => Int
-    t1 = 0
-    t2 :: (FindEnv Int '[Env1, Root] ~ '[Env1]) => Int
-    t2 = 0
-    t3 :: Trans Env1 '[Env1] => Lens' Env1 Env1
-    t3 = transL @Env1 @'[Env1]
-    t4 :: Lens' Env1 Env1
-    t4 = t3
-
--}

--- a/test/Control/Env/Hierarchical/InternalSpec.hs
+++ b/test/Control/Env/Hierarchical/InternalSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -9,10 +10,11 @@
 module Control.Env.Hierarchical.InternalSpec where
 
 import Control.Env.Hierarchical.Internal
-  ( Environment (Fields, Fields1),
+  ( Environment (Fields, Fields1, superL),
+    Extends (Extends),
     Field (fieldL),
     Has,
-    Root,
+    Root (Root),
     Super,
     getL,
     runIF,
@@ -55,7 +57,7 @@ data Env1 = Env1
 makeLenses ''Env1
 
 data Env2 = Env2
-  { _env1 :: Env1,
+  { _env1 :: Extends Env1,
     _obj2 :: Obj2 Env2,
     _param2 :: Param2
   }
@@ -65,17 +67,13 @@ makeLenses ''Env2
 instance Environment Env1 where
   type Fields1 Env1 = '[Obj1]
   type Fields Env1 = '[Env1, Obj1 Env1, Param1]
-
-type instance Super Env1 = Root
+  type Super Env1 = Root
+  superL f x = x <$ f Root
 
 instance Environment Env2 where
   type Fields1 Env2 = '[Obj2]
-  type Fields Env2 = '[Env2, Env1, Obj2 Env2, Param2]
-
-type instance Super Env2 = Env1
-
-instance Field Env1 Env1 where
-  fieldL = id
+  type Fields Env2 = '[Extends Env1, Obj2 Env2, Param2]
+  type Super Env2 = Env1
 
 instance Field (Obj1 Env1) Env1 where
   fieldL = obj1
@@ -83,10 +81,7 @@ instance Field (Obj1 Env1) Env1 where
 instance Field Param1 Env1 where
   fieldL = param1
 
-instance Field Env2 Env2 where
-  fieldL = id
-
-instance Field Env1 Env2 where
+instance Field (Extends Env1) Env2 where
   fieldL = env1
 
 instance Field (Obj2 Env2) Env2 where
@@ -118,31 +113,30 @@ env2Impl =
             _method4 = pure 4
           },
       _param2 = Param2 2,
-      _env1 = env1Impl
+      _env1 = Extends env1Impl
     }
 
-data Env3 env = Env3 Param3 env
+data Env3 env = Env3 Param3 (Extends env)
 
 instance Environment (Env3 env) where
   type Fields (Env3 env) = '[Param3]
   type Fields1 (Env3 env) = '[]
+  type Super (Env3 env) = env
 
-type instance Super (Env3 env) = env
-
-instance {-# INCOHERENT #-} Field env (Env3 env) where
+instance Field (Extends env) (Env3 env) where
   fieldL f (Env3 x1 x2) = fmap (\y2 -> Env3 x1 y2) (f x2)
 
 instance Field Param3 (Env3 env) where
   fieldL f (Env3 x1 x2) = fmap (\y1 -> Env3 y1 x2) (f x1)
 
-newtype Obj3 env = Obj3 (RIO env Int)
+newtype Obj3 env = Obj3 {_runObj3 :: RIO env Int}
   deriving (Generic)
 
 instance Interface Obj3 where
   type IBase Obj3 = RIO
 
-example3 :: Has Param1 env => Obj3 env
-example3 = mapBaseRIO (Env3 (Param3 0)) $
+obj3Impl :: Has Param1 env => Obj3 env
+obj3Impl = mapBaseRIO (Env3 (Param3 3) . Extends) $
   Obj3 $ do
     Param3 n <- view getL
     Param1 m <- view getL
@@ -192,3 +186,7 @@ spec = do
       n <- runRIO env2Impl $ do
         runIF @Obj2 _method3
       n `shouldBe` 3
+    it "runIF @Obj3 from Env1" $ do
+      n <- runRIO env1Impl $ do
+        _runObj3 obj3Impl
+      n `shouldBe` 4

--- a/test/Control/Env/Hierarchical/THSpec.hs
+++ b/test/Control/Env/Hierarchical/THSpec.hs
@@ -11,6 +11,7 @@ module Control.Env.Hierarchical.THSpec where
 
 import Control.Env.Hierarchical.Internal
   ( Environment (Fields, Fields1),
+    Extends,
     Field (fieldL),
     Root,
     Super,
@@ -45,12 +46,18 @@ mkEnv =
 
 deriveEnv ''Env
 
-type instance Super (Env f a) = Root
+newtype Param1 = Param1 Int
+
+data Env2 = Env2 (Extends E) Param1
+
+deriveEnv ''Env2
 
 spec :: Spec
 spec = describe "deriveEnv" $ do
   it "`Super E` is Root" $ do
     typeRep (Proxy @(Super E)) `shouldBe` typeRep (Proxy @Root)
+  it "`Super Env2` is E" $ do
+    typeRep (Proxy @(Super Env2)) `shouldBe` typeRep (Proxy @E)
   it "`Fields E` is '[E, Int, Bool, Maybe E, Either Int E, F E]" $ do
     typeRep (Proxy @(Fields E))
       `shouldBe` typeRep (Proxy @'[E, Int, Bool, Maybe E, Either Int E, F E])


### PR DESCRIPTION

* Change how to specify the super environment
  * Before: Specify by adding type instance for `Super env`
    
    ```haskell
    data Env = Env !BaseEnv !Int
    deriveEnv ''Env
    type instance Super Env = BaseEnv
    ```
  * After: Wrapping the super environment field with `Extends`

    ```haskell
    data Env = Env !(Extends BaseEnv) !Int
    deriveEnv ''Env
    ```
* Fix the type error bug occurs when hiding dependencies.

  ```haskell
  data Env env = Env Param2 (Extends env)
  newtype Obj env = Obj { _foo :: RIO env Int }
  newtype Param1 = Param1 Int
  newtype Param2 = Param2 Int
  
  objImpl :: Has Param1 env => Obj env
  objImpl = mapBaseRIO (Env (Param2 2) . Extends) Obj { _foo = fooImpl }

  fooImpl :: (Has Param1 env, Has Param2 env) => RIO env Int
  fooImpl = do
    Param1 n <- view getL
    Param2 m <- view getL
    pure $ n + m
  ```
